### PR TITLE
Modified link to output directories to use BasePath

### DIFF
--- a/jobsub/examples/anemone-2FEI4/config.cfg
+++ b/jobsub/examples/anemone-2FEI4/config.cfg
@@ -51,10 +51,10 @@ HotpixelRunNumber	= @RunNumber@
 SkipNEvents		= 0
 
 # Output subfolder structure
-DatabasePath		= ./output/database
-HistogramPath		= ./output/histograms
-LcioPath            	= ./output/lcio
-LogPath			= ./output/logs
+DatabasePath		= %(BasePath)s/output/database
+HistogramPath		= %(BasePath)s/output/histograms
+LcioPath            	= %(BasePath)s/output/lcio
+LogPath			= %(BasePath)s/output/logs
 
 # Limit processing of a run to a certain number of events
 MaxRecordNumber		= 10000


### PR DESCRIPTION
Modified links so that paths to output directories use BathPath (as other examples do)
