### PR TITLE
Fixed syntax error which breaks EUTelescope

### DIFF
--- a/src/EUTelAPIXTbTrackTuple.cc
+++ b/src/EUTelAPIXTbTrackTuple.cc
@@ -260,7 +260,7 @@ bool EUTelAPIXTbTrackTuple::readHits( std::string hitColName, LCEvent* event )
     		double z = pos[2];
    			
 		//undo GEAR rotations
-		/rotMat rot = _invDUTRot.at(sensorID);
+		rotMat rot = _invDUTRot.at(sensorID);
 		double xUnRot = rot.r1*x + rot.r2*y;
 		double yUnRot = rot.r3*x + rot.r4*y;
  


### PR DESCRIPTION
After compiling and testing the code I included some comments, unfortunately a "/" made it into a line where it should not be - sorry for that! Fixed now!
