### PR TITLE
FIX steering template for hitmaker step: 

### DIFF
--- a/jobsub/examples/datura-noDUT/steering-templates/hitmaker-tmp.xml
+++ b/jobsub/examples/datura-noDUT/steering-templates/hitmaker-tmp.xml
@@ -65,7 +65,7 @@
 <processor name="HitMakerM26" type="EUTelProcessorHitMaker">
 	<!--EUTelProcessorHitMaker is responsible to translate cluster centers from the local frame of reference to the external frame of reference using the GEAR geometry description-->
 	<!--Hit coordinates are calculated in local reference frame of sensor-->
-	<!--parameter name="EnableLocalCoordidates" type="bool">false </parameter-->
+	<parameter name="EnableLocalCoordidates" type="bool">false </parameter>
 	<!--Hit collection name-->
 	<parameter name="HitCollectionName" type="string" lcioOutType="TrackerHit"> hit </parameter>
 		<!--Cluster (pulse) collection name-->


### PR DESCRIPTION
since the HitMaker processor produces hits in Local frame by default
and EUTelMille expects them in Global as before.

therefore have to fix it in the steering template // uncommenting the "false" flag
