### PR TITLE
exclude planes from the pre alignment process

### DIFF
--- a/include/EUTelPreAlignment.h
+++ b/include/EUTelPreAlignment.h
@@ -234,7 +234,8 @@ namespace eutelescope {
     gear::SiPlanesParameters * _siPlanesParameters;
     gear::SiPlanesLayerLayout * _siPlanesLayerLayout;
     std::vector<PreAligner> _preAligners;
-  };
+    std::vector<int> _ExcludedPlanes;  
+};
   //! A global instance of the processor
   EUTelPreAlign gEUTelPreAlign;
 

--- a/src/EUTelCorrelator.cc
+++ b/src/EUTelCorrelator.cc
@@ -609,7 +609,7 @@ void EUTelCorrelator::end() {
  
     if( _hasHitCollection)
     {
-        streamlog_out( MESSAGE5 ) << "The input CollectionVec contains HitCollection, calculating offest values " << endl;
+        streamlog_out( MESSAGE5 ) << "The input CollectionVec contains HitCollection, calculating offset values " << endl;
  
         for ( size_t exx = 0 ; exx < geo::gGeometry().nPlanes(); exx++ ) 
         {           

--- a/src/EUTelPreAlignment.cc
+++ b/src/EUTelPreAlignment.cc
@@ -95,6 +95,8 @@ EUTelPreAlign::EUTelPreAlign () :Processor("EUTelPreAlign") {
 
   registerOptionalParameter("HistogramFilling","Switch on or off the histogram filling",_fillHistos, static_cast< bool > ( true ) );
 
+  registerOptionalParameter("ExcludedPlanes", "The list of sensor IDs that shall be excluded.",_ExcludedPlanes, std::vector<int> () );
+
 }
 
 
@@ -523,23 +525,27 @@ void EUTelPreAlign::end() {
 
 
   for(size_t ii = 0 ; ii < _preAligners.size(); ii++){
-    EUTelAlignmentConstant* constant = new EUTelAlignmentConstant();
-
-    if( abs( _preAligners.at(ii).getPeakX() ) < 1000. )
-      constant->setXOffset( -1.0 * _preAligners.at(ii).getPeakX() );
-    else
-      constant->setXOffset( -1.0 * 0.0                           );
- 
-    if( abs( _preAligners.at(ii).getPeakY() ) < 1000. )
-      constant->setYOffset( -1.0 * _preAligners.at(ii).getPeakY() );
-    else
-      constant->setYOffset( -1.0 * 0.0                           );
- 
-    int sensorID = _preAligners.at(ii).getIden();
-    constant->setSensorID( sensorID );
-    constantsCollection->push_back( constant );
-    streamlog_out ( MESSAGE5 ) << (*constant) << endl;
+	int sensorID = _preAligners.at(ii).getIden();
+	__gnu_cxx::__normal_iterator<int*, std::vector<int> > it = find(_ExcludedPlanes.begin(),_ExcludedPlanes.end(),sensorID);
+	EUTelAlignmentConstant* constant = new EUTelAlignmentConstant();
+	if(it == _ExcludedPlanes.end()){
+	    if( abs( _preAligners.at(ii).getPeakX() ) < 1000. )
+	      constant->setXOffset( -1.0 * _preAligners.at(ii).getPeakX() );
+	    else
+	      constant->setXOffset( -1.0                            );
+	 
+	    if( abs( _preAligners.at(ii).getPeakY() ) < 1000. )
+	      constant->setYOffset( -1.0 * _preAligners.at(ii).getPeakY() );
+	    else
+	      constant->setYOffset( -1.0                            );
+	}else{
+	    constant->setXOffset(0.0); constant->setYOffset(0.0);
+	}
+	constant->setSensorID( sensorID );
+	constantsCollection->push_back( constant );
+	streamlog_out ( MESSAGE5 ) << (*constant) << endl;
   }
+
 
   streamlog_out( DEBUG5 ) << " adding Collection " << "alignment " << endl;
  


### PR DESCRIPTION
added optional parameter allowing the user to exclude planes from the pre alignment process and instead just set the offset values to zero.

fixed a small typo