### PR TITLE
New features and bug fixes for the pALPIDEfs

### DIFF
--- a/include/EUTelClusteringProcessor.h
+++ b/include/EUTelClusteringProcessor.h
@@ -32,8 +32,6 @@
 #include <IMPL/TrackerRawDataImpl.h>
 #include <IMPL/LCCollectionVec.h>
 
-#include "TH1.h"
-
 // system includes <>
 #include <string>
 #include <map>
@@ -813,7 +811,7 @@ namespace eutelescope {
     std::map<int,AIDA::IBaseHistogram*> _eventMultiplicityHistos;
 
     // Histogram for the timestamp of the events
-    TH1* _timeStampHisto;
+    AIDA::IBaseHistogram* _timeStampHisto;
     //! Map (of maps) for pointers to histograms with cluster spectra with the X most significant pixels
     std::map<int, std::map<int,AIDA::IBaseHistogram*> > _clusterSignal_NHistos;
 

--- a/include/EUTelClusteringProcessor.h
+++ b/include/EUTelClusteringProcessor.h
@@ -32,6 +32,8 @@
 #include <IMPL/TrackerRawDataImpl.h>
 #include <IMPL/LCCollectionVec.h>
 
+#include "TH1.h"
+
 // system includes <>
 #include <string>
 #include <map>
@@ -810,6 +812,8 @@ namespace eutelescope {
     //! Map for pointer to Event multiplicity histogram
     std::map<int,AIDA::IBaseHistogram*> _eventMultiplicityHistos;
 
+    // Histogram for the timestamp of the events
+    TH1* _timeStampHisto;
     //! Map (of maps) for pointers to histograms with cluster spectra with the X most significant pixels
     std::map<int, std::map<int,AIDA::IBaseHistogram*> > _clusterSignal_NHistos;
 

--- a/jobsub/examples/pALPIDEfs/config_pALPIDEfs_7.cfg
+++ b/jobsub/examples/pALPIDEfs/config_pALPIDEfs_7.cfg
@@ -1,0 +1,141 @@
+# =============================================================================
+#
+# examples/pALPIDEfs
+#
+# =============================================================================
+#
+# Check the README for information
+#
+# =============================================================================
+#
+# Global section. Settings can be overwritten through task-specific sections
+# The python config parser interprets '%(NAME)s' as the corresponding variable
+# NAME. The variable 'eutelescopepath' is by default filled with the environment
+# variable EUTELESCOPE and should correspond to the installation path of
+# EUTelescope. Also, the variable '%(home)s' corresponds to the user's home
+# directory. The template file name can be set with TemplateFile = file.xml. The
+# default is '[task]-tmp.xml'
+
+# Example data files can be found here:
+# Beam data: https://cernbox.cern.ch/public.php?service=files&t=26739ef013fdb23a93c798d9fc19389b
+# Noise data: https://cernbox.cern.ch/public.php?service=files&t=5b5faa98710b04a1eb83ed1308115397
+
+[DEFAULT]
+
+# The path to this config file
+BasePath		= %(eutelescopepath)s/jobsub/examples/pALPIDEfs
+
+# The location of the steering templates
+TemplatePath		= %(BasePath)s/steering-templates_pALPIDEfs_7
+
+# The GEAR file describing the detector geometry, this is passed from the
+# runlist.csv
+GearFile    	        = @GearGeoFile@
+
+# Path to the GEAR files
+GearFilePath    	= %(BasePath)s
+
+
+# The XML file with histogram information
+HistoInfoFile   	= %(TemplatePath)s/histoinfo.xml
+
+# Formats the output; @RunNumber@ is the current run number padded with leading
+# zeros to 6 digits
+FilePrefix   	 	= run@RunNumber@	
+
+# Which run number to use for hot pixel determination
+HotpixelRunNumber	= @RunNumber@
+
+# Skip events in a run; set to 0 for all data
+SkipNEvents		= 0
+
+# Limit processing of a run to a certain number of events
+MaxRecordNumber		= 10000000
+
+# The verbosity used by the EUTelescope producers (i.e. MESSAGE, DEBUG, ERROR
+# with appended level from 0..9, e.g. MESSAGE5). If you set this to DEBUG0 but
+# you do not see any DEBUG messages, make sure that you set CMAKE_BUILD_TYPE to
+# Debug in the $EUTELESCOPE/CMakeList.txt file.
+Verbosity		= MESSAGE4
+
+# Section for the converter step
+[converter]
+
+# Section for the noise analysis step
+[noise]
+
+# Section for the hotpixel treatement in the pAlpide
+[hotpixel]
+nEventsForHotpixel      = 9999
+
+# Search for dead columns in chip
+[deadColumn]
+
+# Section for the clustering step
+[clustering]
+#FFSeedCut               = 25.0
+#FFPixelCut              = 3.0
+
+# Section for the hitmaker step
+[hitmaker]
+
+# Section for the prealignment
+[prealign]
+
+# Reduce events for alignment, overwriting global value set above
+MaxRecordNumber         = 500000
+
+# Section for the old straightline alignment
+[align]
+
+# Reduce events for alignment, overwriting global value set above
+MaxRecordNumber		= 1000000
+
+# Run Millepede? 0 = false, 1 = true
+RunPede			= 1
+
+# Use residual cuts? 0 = false, 1 = true
+UseResidualCuts		= 1
+
+# The residual cuts in um per plane
+
+ResidualXMin		= -500. -500. -500. -500. -500. -500. -500.
+ResidualXMax		=  500.  500.  500.  500.  500.  500.  500.
+ResidualYMin		= -500. -500. -500. -500. -500. -500. -500.
+ResidualYMax		=  500.  500.  500.  500.  500.  500.  500.
+
+# Maximum distance in um for for matches used in EUTelMille/findTrack:
+DistanceMax		= 10000
+
+# Planes to exclude in alignment (not regarded at all)
+#ExcludePlanes		= 
+
+# Planes to consider as fixed in alignment (these planes are included in the
+# alignment but with fixed positions)
+FixedPlanes		= 0 6
+ResolutionX             = 64.38 64.38 64.38 64.38 64.38 64.38 64.38
+ResolutionY             = 64.38 64.38 64.38 64.38 64.38 64.38 64.38
+#ResolutionX             = 22.1 22.1 22.1 22.1 22.1  
+#ResolutionY             = 22.1 22.1 22.1 22.1 22.1
+
+#Section to check alignment
+[align-check]
+
+# Section for the fitter step
+[fitter]
+
+# TestFitter options
+AllowedSkipHits		= 0
+SkipHitPenalty		= 0 
+AllowedMissingHits	= 2
+MissingHitPenalty	= 0 
+Chi2Max			= 30.0 # was 1000
+#PassiveLayerIDs		= @dutID@
+SlopeDistanceMax	= 10000.0
+SkipLayerIDs            =  
+#ManualDUTid             = @dutID@
+
+# Section for analysing the fitted tracks
+[analysis]
+#dutID                   = 10
+NoiseMaskFileName       = @NoiseMask@

--- a/jobsub/examples/pALPIDEfs/runlist_example.csv
+++ b/jobsub/examples/pALPIDEfs/runlist_example.csv
@@ -1,0 +1,4 @@
+RunNumber,BeamEnergy,GearGeoFile,DUTNumbers,ChipIDs,IrradiationLevel,Rate
+
+2850,6.0,gear_pALPIDEfs_example_withCarrierMaterial.xml,2 3 4,W1-18 W2-27 W6-39 W9-16 W6-14 W2-23 W1-17,0 0 0 0 0 0 0,PS
+2876,0.0,gear_pALPIDEfs_example_withCarrierMaterial.xml,2 3 4,W1-18 W2-27 W6-39 W9-16 W6-14 W2-23 W1-17,0 0 0 0 0 0 0,PS

--- a/jobsub/examples/pALPIDEfs/steering-templates_pALPIDEfs_7/fitter-tmp.xml
+++ b/jobsub/examples/pALPIDEfs/steering-templates_pALPIDEfs_7/fitter-tmp.xml
@@ -179,6 +179,8 @@ WARNING: - Please be aware that comments made in the original steering file were
   <parameter name="ResidualsYMax" type="FloatVec"> 5. 5. 5. 5. 5. 5. 5. </parameter>
   <!--Minimal values of the hit residuals in the Y direction for a correlation band. Note: these numbers are ordered according to the z position of the sensors and NOT according to the sensor id.-->
   <parameter name="ResidualsYMin" type="FloatVec"> -5. -5. -5. -5. -5. -5. -5. </parameter>
+  <!--Name of histogram info xml file-->
+  <parameter name="HistogramInfoFilename" type="string" value="@HistoInfoFile@"/>
   <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
   <!--parameter name="Verbosity" type="string" value=""/-->
 </processor>

--- a/jobsub/examples/pALPIDEfs/steering-templates_pALPIDEfs_7/hotpixel-tmp.xml
+++ b/jobsub/examples/pALPIDEfs/steering-templates_pALPIDEfs_7/hotpixel-tmp.xml
@@ -99,7 +99,7 @@
     <!--The total number of hot pixel cycle-->
   <parameter name="TotalNoOfCycle" type="int" value="0"/>
     <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-  <!--parameter name="Verbosity" type="string" value=""/-->
+  <parameter name="Verbosity" type="string" value="MESSAGE6"/>
 </processor>
 
  <processor name="Save" type="EUTelOutputProcessor">

--- a/jobsub/examples/pALPIDEfs/steering-templates_pALPIDEfs_7/prealign-tmp.xml
+++ b/jobsub/examples/pALPIDEfs/steering-templates_pALPIDEfs_7/prealign-tmp.xml
@@ -108,7 +108,7 @@
   <!--Minimal values of the hit residuals in the Y direction for a correlation band. Note: these numbers are ordered according to the z position of the sensors and NOT according to the sensor id.-->
   <parameter name="ResidualsYMin" type="FloatVec"> -5. -5. -5. -5. -5. -5. -5. </parameter>
   <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
-  <!--parameter name="Verbosity" type="string" value="SILENT"/-->
+  <parameter name="Verbosity" type="string" value="WARNING3"/>
 </processor>
 
  <processor name="Save" type="EUTelOutputProcessor">

--- a/src/AnalysisPALPIDEfs.cc
+++ b/src/AnalysisPALPIDEfs.cc
@@ -570,6 +570,7 @@ void AnalysisPALPIDEfs::processEvent(LCEvent *evt)
               if (nDUThitsEvent > 1) nDUThits++;
               if (abs(xpos-xposfit) < limit && abs(ypos-yposfit) < limit )
               {
+                nAssociatedhits++;
                 for (int jhit=ihit+1; jhit< nHit ; jhit++)
                 {
                   TrackerHit * hitNext = dynamic_cast<TrackerHit*>( col->getElementAt(jhit) ) ;
@@ -604,6 +605,7 @@ void AnalysisPALPIDEfs::processEvent(LCEvent *evt)
                     double yposNext = (xPointing[0]*posNext[1]-yPointing[0]*posNext[0])/(yPointing[1]*xPointing[0]-yPointing[0]*xPointing[1]);
                     double xposNext = posNext[0]/xPointing[0] - xPointing[1]/xPointing[0]*yposNext;
                     if (abs(xposNext-xposfit) > limit || abs(yposNext-yposfit) > limit) continue;
+                    nAssociatedhits++;
                     if ((xpos-xposfit)*(xpos-xposfit)+(ypos-yposfit)*(ypos-yposfit)<(xposNext-xposfit)*(xposNext-xposfit)+(yposNext-yposfit)*(yposNext-yposfit)) 
                     {
                       ihit = jhit;
@@ -618,13 +620,9 @@ void AnalysisPALPIDEfs::processEvent(LCEvent *evt)
                     }
                   }
                 }
-                nAssociatedhits++;
                 if (nDUThitsEvent > 1 && nAssociatedhits == 1) {tmpHist->Fill(xposfitPrev,yposfitPrev); nWrongPAlpideHit--;}
                 if (nAssociatedhits > 1) 
-                {
-                  cerr << nAssociatedhits << " points for one track in DUT in event " << evt->getEventNumber() << "\t" << xposPrev << "\t" << yposPrev << "\t" << xpos << "\t" << ypos << " Fit: " << xposfit << "\t" << yposfit << " Number of planes with more than one hit: " << nPlanesWithMoreHits << endl;
-                  break;
-                }
+                  streamlog_out ( DEBUG )  << nAssociatedhits << " points for one track in DUT in event " << evt->getEventNumber() << "\t" << xposPrev << "\t" << yposPrev << "\t" << xpos << "\t" << ypos << " Fit: " << xposfit << "\t" << yposfit << " Number of planes with more than one hit: " << nPlanesWithMoreHits << endl;
                 if (_clusterAvailable)
                 {
                   for ( unsigned int idetector=0 ; idetector<zsInputDataCollectionVec->size(); idetector++)

--- a/src/EUTelClusteringProcessor.cc
+++ b/src/EUTelClusteringProcessor.cc
@@ -703,7 +703,7 @@ void EUTelClusteringProcessor::processEvent (LCEvent * event)
     }
 #endif
 
-    _timeStampHisto->Fill(event->getTimeStamp());
+    (dynamic_cast<AIDA::IHistogram1D*> (_timeStampHisto))->fill(event->getTimeStamp());
     EUTelEventImpl * evt = static_cast<EUTelEventImpl*> (event);
     if ( evt->getEventType() == kEORE )
     {
@@ -2845,7 +2845,17 @@ void EUTelClusteringProcessor::check (LCEvent * /* evt */) {
 
 
 void EUTelClusteringProcessor::end() {
-streamlog_out ( MESSAGE4 ) << "Maximum of the time stamp histo is at " << _timeStampHisto->GetBinCenter(_timeStampHisto->GetMaximumBin()) << endl;
+    int max = 0, maxBin = -1;
+    for (int iBin=0; iBin<1000; iBin++)
+    {
+      int binEntry = (dynamic_cast<AIDA::IHistogram1D*> (_timeStampHisto))->binEntries(iBin);
+      if (binEntry > max)
+      {
+        max = binEntry;
+        maxBin = iBin;
+      }
+    }
+    streamlog_out ( MESSAGE4 ) << "Maximum of the time stamp histo is at " << (dynamic_cast<AIDA::IHistogram1D*> (_timeStampHisto))->binMean(maxBin) << endl;
     streamlog_out ( MESSAGE2 ) <<  "Successfully finished" << endl;
 
     map< int, int >::iterator iter = _totClusterMap.begin();
@@ -3451,7 +3461,8 @@ void EUTelClusteringProcessor::bookHistos() {
         _eventMultiplicityHistos.insert( make_pair(sensorID, eventMultiHisto) );
         eventMultiHisto->setTitle( eventMultiTitle.c_str() );
     }
-    _timeStampHisto = new TH1I("timeStampHisto","Distribution of the time stamp of the events",1000,0,50000);
+    _timeStampHisto = AIDAProcessor::histogramFactory(this)->createHistogram1D("timeStampHisto",1000,0,50000);
+    _timeStampHisto->setTitle("Distribution of the time stamp of the events");
     streamlog_out ( DEBUG5 )  << "end of Booking histograms " << endl;
 }
 

--- a/src/EUTelClusteringProcessor.cc
+++ b/src/EUTelClusteringProcessor.cc
@@ -703,6 +703,7 @@ void EUTelClusteringProcessor::processEvent (LCEvent * event)
     }
 #endif
 
+    _timeStampHisto->Fill(event->getTimeStamp());
     EUTelEventImpl * evt = static_cast<EUTelEventImpl*> (event);
     if ( evt->getEventType() == kEORE )
     {
@@ -2844,7 +2845,7 @@ void EUTelClusteringProcessor::check (LCEvent * /* evt */) {
 
 
 void EUTelClusteringProcessor::end() {
-
+streamlog_out ( MESSAGE4 ) << "Maximum of the time stamp histo is at " << _timeStampHisto->GetBinCenter(_timeStampHisto->GetMaximumBin()) << endl;
     streamlog_out ( MESSAGE2 ) <<  "Successfully finished" << endl;
 
     map< int, int >::iterator iter = _totClusterMap.begin();
@@ -3450,6 +3451,7 @@ void EUTelClusteringProcessor::bookHistos() {
         _eventMultiplicityHistos.insert( make_pair(sensorID, eventMultiHisto) );
         eventMultiHisto->setTitle( eventMultiTitle.c_str() );
     }
+    _timeStampHisto = new TH1I("timeStampHisto","Distribution of the time stamp of the events",1000,0,50000);
     streamlog_out ( DEBUG5 )  << "end of Booking histograms " << endl;
 }
 


### PR DESCRIPTION
Hi,

We would like to merge our newest changes for the EUTelescope software. We added a few changes related to the pALPIDEfs:
- A bug in the analysis code of the pALPIDEfs was corrected
- Log levels in the example steering templates were adjusted
- An example config file and runlist for the pALPIDEfs was added. Now the config file contains the path pointing to our example data. Would you prefer to move these two files to a DESY server or is distributing them like this fine for you?

There was one change in the EUTelClusteringProcessor.cc code also where a new histogram which stores the time stamps of the events was added and some log output related to this histogram was also added.

Best regards,
Monika