### PR TITLE
Global to local transformation in APIXTbTrackTuple

### DIFF
--- a/src/EUTelAPIXTbTrackTuple.cc
+++ b/src/EUTelAPIXTbTrackTuple.cc
@@ -249,7 +249,8 @@ bool EUTelAPIXTbTrackTuple::readTracks(LCEvent* event)
 		double dxdz = fittrack->getOmega();
 		double dydz = fittrack->getPhi();
 
- 		//Get the (fitted) hits belonging to this track, they are in local frame!
+ 		/* Get the (fitted) hits belonging to this track, 
+		   they are in global frame when coming from the straight track fitter */
 		for(unsigned int ihit=0; ihit< trackhits.size(); ihit++)
 	       	{
       			TrackerHitImpl* fittedHit = dynamic_cast<TrackerHitImpl*>( trackhits.at(ihit) );
@@ -269,12 +270,14 @@ bool EUTelAPIXTbTrackTuple::readTracks(LCEvent* event)
 			}
 
       			nTrackParams++;
-      			
-				double x = pos[0];
-      			double y = pos[1];
-      			//double z = pos[2]; //not used!
+      			/* Transform to local coordinates */
+			double pos_loc[3];
+			geo::gGeometry().master2Local(sensorID, pos, pos_loc);
 			
-				//eutrack tree
+			double x = pos_loc[0];
+			double y = pos_loc[1];
+
+			//eutrack tree
       			_xPos->push_back(x);
       			_yPos->push_back(y);
       			_dxdz->push_back(dxdz);

--- a/src/EUTelAPIXTbTrackTuple.cc
+++ b/src/EUTelAPIXTbTrackTuple.cc
@@ -167,7 +167,7 @@ void EUTelAPIXTbTrackTuple::processEvent( LCEvent * event )
 void EUTelAPIXTbTrackTuple::end()
 {
 	//write version number
-	_versionNo->push_back(1.1);
+	_versionNo->push_back(1.2);
 	_versionTree->Fill();
 	//Maybe some stats output?
 	_file->Write();


### PR DESCRIPTION
Transform hits from tracks from global to local coordinates in ReadTracks()
The output of the straight track EUTelTestFitter is in global coordinates, so this transformation is needed.