### PR TITLE
Save tot as double instead of int

### DIFF
--- a/include/EUTelAPIXTbTrackTuple.h
+++ b/include/EUTelAPIXTbTrackTuple.h
@@ -72,7 +72,7 @@ namespace eutelescope {
     int _nPixHits;
     std::vector<int> *p_col;
     std::vector<int> *p_row;
-    std::vector<int> *p_tot;
+    std::vector<double> *p_tot;
     std::vector<int> *p_iden;
     std::vector<int> *p_lv1;
     std::vector<int> *p_chip;

--- a/src/EUTelAPIXTbTrackTuple.cc
+++ b/src/EUTelAPIXTbTrackTuple.cc
@@ -324,8 +324,8 @@ bool EUTelAPIXTbTrackTuple::readZsHits( std::string colName, LCEvent* event)
 				p_iden->push_back( sensorID );
 				p_row->push_back( apixPixel.getYCoord() );
 				p_col->push_back( apixPixel.getXCoord() );
-				p_tot->push_back( static_cast< int >(apixPixel.getSignal()) );
-				p_lv1->push_back( static_cast< int >(apixPixel.getTime()) );
+				p_tot->push_back( apixPixel.getSignal() );
+				p_lv1->push_back( apixPixel.getTime() );
      		}
     	}
 		else
@@ -376,7 +376,7 @@ void EUTelAPIXTbTrackTuple::prepareTree()
 
 	p_col = new std::vector<int>();
 	p_row = new std::vector<int>();
-	p_tot = new std::vector<int>();
+	p_tot = new std::vector<double>();
 	p_iden = new std::vector<int>();
 	p_lv1 = new std::vector<int>();
 
@@ -404,7 +404,7 @@ void EUTelAPIXTbTrackTuple::prepareTree()
 	_zstree->Branch("euEvt",    &_nEvt);
 	_zstree->Branch("col",      &p_col);
 	_zstree->Branch("row",      &p_row);
-	_zstree->Branch("tot",      &p_tot);
+	_zstree->Branch("tot", "std::vector<double>",     &p_tot);
 	_zstree->Branch("lv1",      &p_lv1);
 	_zstree->Branch("iden",     &p_iden);
 


### PR DESCRIPTION
Changed variable p_tot to double. 
In the Mupix chip analysis we use the signal and time of a hit to store two different timestamps. For one of them we need double precision, so we use p_tot as a double.