### PR TITLE
Native jobsub NAF support

### DIFF
--- a/jobsub/README
+++ b/jobsub/README
@@ -7,7 +7,7 @@
 #+begin_example
 usage: jobsub.py [-h] [--option NAME=VALUE] [-c FILE] [-csv FILE]
                  [--log-file FILE] [-l LEVEL] [-s] [--dry-run]
-		 [--naf FILE]
+		 [--naf FILE] [--subdir]
                  jobtask [runs [runs ...]]
 
 A tool for the convenient run-specific modification of Marlin steering files
@@ -48,6 +48,8 @@ optional arguments:
   --dry-run             Write steering files but skip actual Marlin execution
   --naf FILE            Do not execute Marlin directly but submit the job to NAF.
                         The file contains parameters for the qsub utility.
+  --subdir              Creates a separate subdirectory for every run. This can avoid problems
+                        with overwriting output files such as the "millepede.res" file from pede
 #+end_example
 * Preparation of Steering File Templates
   Steering file templates are valid Marlin steering files (in xml

--- a/jobsub/README
+++ b/jobsub/README
@@ -7,6 +7,7 @@
 #+begin_example
 usage: jobsub.py [-h] [--option NAME=VALUE] [-c FILE] [-csv FILE]
                  [--log-file FILE] [-l LEVEL] [-s] [--dry-run]
+		 [--naf FILE]
                  jobtask [runs [runs ...]]
 
 A tool for the convenient run-specific modification of Marlin steering files
@@ -45,6 +46,8 @@ optional arguments:
                         or error
   -s, --silent          Suppress non-error (stdout) Marlin output to console
   --dry-run             Write steering files but skip actual Marlin execution
+  --naf FILE            Do not execute Marlin directly but submit the job to NAF.
+                        The file contains parameters for the qsub utility.
 #+end_example
 * Preparation of Steering File Templates
   Steering file templates are valid Marlin steering files (in xml

--- a/jobsub/examples/README
+++ b/jobsub/examples/README
@@ -8,6 +8,9 @@ that can be used as a basis for your own analysis:
 * datura-noDUT
      The Datura telescope with six planes of Mimosa26 without DUT
 
+* naf-submission
+     Example file for the qsub parameters needed for NAF job submission
+
 All examples are also being used for automated data-driven tests using
 the CMake/CTest framework to verify the correct functionality of
 EUTelescope; see 'datura-alone/testing.cmake' for an example setup for

--- a/jobsub/examples/naf-submission/qsubparameters.cfg
+++ b/jobsub/examples/naf-submission/qsubparameters.cfg
@@ -1,0 +1,14 @@
+# Change to the directory where the batch job is submitted:
+-cwd
+# Send mail after the end(s), begin(b), abort(a) or suspend(s) of the batch jobs
+-m a
+# Treat command as (b)inary, not as script
+-b yes
+# Required job running time:
+-l h_rt=12:00:00
+# Export all environment variables active within qsub to the context of the job
+-V
+# reserve 4GB of RAM
+-l h_vmem=4000M
+# merge stderr and stdout together to stdout
+-j y

--- a/jobsub/jobsub.py
+++ b/jobsub/jobsub.py
@@ -474,7 +474,7 @@ def main(argv=None):
 
     # dictionary keeping our parameters
     # here you can set some minimal default config values that will (possibly) be overwritten by the config file
-    parameters = {"templatepath":".", "templatefile":args.jobtask+"-tmp.xml", "logpath":".", "qsubconfig":"qsubparameters.txt"}
+    parameters = {"templatepath":".", "templatefile":args.jobtask+"-tmp.xml", "logpath":"."}
 
     # read in config file if specified on command line
     if args.conf_file:

--- a/jobsub/jobsub.py
+++ b/jobsub/jobsub.py
@@ -300,7 +300,7 @@ def runMarlin(filenamebase, jobtask, silent):
         exit(1)
     return rcode
 
-def submitNAF(filenamebase, jobtask, silent):
+def submitNAF(filenamebase, jobtask, runnr):
     """ Submits the Marlin job to NAF """
     import os
     from sys import exit # use sys.exit instead of built-in exit (latter raises exception)
@@ -317,7 +317,7 @@ def submitNAF(filenamebase, jobtask, silent):
 
     # Add qsub parameters:
     #qsub -@ qsubParams.txt BIN
-    cmd = cmd+" -@ ../qsubparameters.txt "
+    cmd = cmd+" -@ ../qsubparameters.txt -N \"Run"+runnr+"\" "
     
     # check for Marlin executable
     marlin = check_program("Marlin")
@@ -643,7 +643,7 @@ def main(argv=None):
         if args.dry_run:
             log.info("Dry run: skipping Marlin execution. Steering file written to "+basefilename+'.xml')
         elif args.naf:
-            rcode = submitNAF(basefilename, args.jobtask, args.silent) # start NAF submission
+            rcode = submitNAF(basefilename, args.jobtask, runnr) # start NAF submission
             if rcode == 0:
                 log.info("NAF job submitted")
             else:


### PR DESCRIPTION
Dear all,

I lately added native support for job submission to NAF to our jobsub tool. This allows to batch process hundreds of runs in parallel with ease. Just one (or two) additional command line arguments for jobsub are necessary, all existing jobsub features are supported.

NAF submission
----

To run a job on the NAF, log into your favourite NAF job submission machine, prepare your EUTelescope installation and data and run jobsub for all jobs to be submitted:
```
jobsub <other options> --naf qsubparameters.dat <step> <runs>
```
where the `qsubparameters.dat` is your NAF job configuration file. A sample file with explanations for all settings that might be relevant for your testbeam analysis can be found in the directory `jobsub/examples/naf-submission`. Obviously you can just copy that file anywhere and adjust it to your needs (more RAM, mroe CPU time, other node architecture...)

The `subdir` option
----

If you are running "problematic" processors such as alignment using Millepede-II which still hast the problem of always producing an output file with the same name, there is an additional switch available from now on:
```
jobsub <other options> --subdir <step> <runs>
```
forces jobsub to produce subdirectories for every job and execute Marlin from therein. This ensures the `millepede.res` files are correctly stored and read for every run separately. This feature is available for both normal execution and NAF submission.

Both new options are also documented in the jobsub help text.

Have fun batch-processing your data!
Bugs and problems with jobsub to me, bugs and problem swith NAF to the NAF support.

/Simon