### PR TITLE
Problem with noisy pixel collection

### DIFF
--- a/include/EUTelMatrixDecoder.h
+++ b/include/EUTelMatrixDecoder.h
@@ -113,8 +113,8 @@ namespace eutelescope {
         _xMin(0),
         _yMin(0)
     {
-      _xNoOfPixel = decoder(rawData)["xMax"] - decoder(rawData)["xMin"];
-      _yNoOfPixel = decoder(rawData)["yMax"] - decoder(rawData)["yMin"];
+      _xNoOfPixel = decoder(rawData)["xMax"] - decoder(rawData)["xMin"] + 1;
+      _yNoOfPixel = decoder(rawData)["yMax"] - decoder(rawData)["yMin"] + 1;
       _xMin       = decoder(rawData)["xMin"];
       _yMin       = decoder(rawData)["yMin"];
 


### PR DESCRIPTION
Hi,

I realized errors like the following appear when we have many noisy pixels is the collection:
15:15:09 jobsub.clustering(ERROR): [ ERROR5 "Clustering_pALPIDEfs"] hot pixel [index 197439] reoccured ?! 

It seems to originate from EUTelMatrixDecoder::getIndexFromXY(x,y), which should give a unique index for each pixel in the noise collection, however for pixels 0,193 and 1023,192 it gives the same index. (We have 1024x512 pixels in our sensor.) The problem is that in EUTelMatrixDecoder.h _xNoOfPixel and _yNoOfPixel is not set correctly to the number of pixels, but it is one less, which can be solved by this commit.

Cheers,
Monika