### PR TITLE
Add option to qsub parameter file

### DIFF
--- a/jobsub/examples/naf-submission/qsubparameters.cfg
+++ b/jobsub/examples/naf-submission/qsubparameters.cfg
@@ -12,3 +12,5 @@
 -l h_vmem=4000M
 # merge stderr and stdout together to stdout
 -j y
+# overwrite limit of output files size (default 3 G) to specified limit
+-l h_fsize=8G


### PR DESCRIPTION
-l h_fsize= ... overwrites the default limit of 3G with the specified value, e.g. =8G