### PR TITLE
Include TMath.h to EUTelAlignGBL

### DIFF
--- a/processors/src/EUTelAlignGBL.cc
+++ b/processors/src/EUTelAlignGBL.cc
@@ -66,6 +66,9 @@
 #include <iostream>
 #include <fstream>
 
+// ROOT includes ".h"
+#include <TMath.h>
+
 using namespace std;
 using namespace lcio;
 using namespace marlin;


### PR DESCRIPTION
EUTelAlignGBL is using TMath::Prob, but the package TMath is not included, thus making the compilation fail.
The other possibility to fix this would be to move the inclusion of TMath in EUTelTripletGBL.cc to EUTelTripletGBLUtility.h, but I think that keeping it explicit in this cc file is cleaner.