### PR TITLE
Book gblutil histograms during EUTelAlignGBL init

### DIFF
--- a/processors/src/EUTelAlignGBL.cc
+++ b/processors/src/EUTelAlignGBL.cc
@@ -340,7 +340,9 @@ void EUTelAlignGBL::init() {
 
   // booking histograms
   bookHistos(_sensorIDVec);
-
+  gblutil.setParent(this);
+  gblutil.bookHistos();
+  
   streamlog_out( MESSAGE2 ) << "Initialising Mille..." << endl;
 
   unsigned int reserveSize = 8000;
@@ -370,8 +372,6 @@ void EUTelAlignGBL::init() {
 
 //------------------------------------------------------------------------------
 void EUTelAlignGBL::processRunHeader( LCRunHeader* rdr ) {
-  gblutil.setParent(this);
-  gblutil.bookHistos();
   auto header = std::make_unique<EUTelRunHeaderImpl>(rdr);
   header->addProcessor( type() ) ;
   // increment the run counter


### PR DESCRIPTION
I am having problems since the gblutil histograms are filled before they are created. It looks like the problem is that they are created when the RunHeader is created, while creating them in the initialization of EUTelAlignGBL fixes this (and this is more consistent with the booking of the other GBL hitstograms)