### PR TITLE
Avoid crashes in GeometricClustering when no collection is present

### DIFF
--- a/processors/src/EUTelProcessorGeometricClustering.cc
+++ b/processors/src/EUTelProcessorGeometricClustering.cc
@@ -180,6 +180,15 @@ void EUTelProcessorGeometricClustering::readCollections(LCEvent *event) {
                           << " not found in event " << event->getEventNumber()
                           << std::endl;
   }
+
+  try {
+    event->getCollection(_zsDataCollectionName);
+  } catch (lcio::DataNotAvailableException &e) {
+    streamlog_out(MESSAGE2)
+        << "The current event doesn't contain nZS data collections: skip # "
+        << event->getEventNumber() << std::endl;
+    throw SkipEventException(this);
+  }
 }
 
 void EUTelProcessorGeometricClustering::processEvent(LCEvent *event) {


### PR DESCRIPTION
I have some data where the FEI4 has missing the zs collection in some events. Somehow, the SparseClustering was working, but not the GeometricClustering. I added the few lines that fix this (they are copied from the SparseClustering processor).

This is a quick and dirty fix. The main question is actually why the same check is performed twice and why the first time the SkipEventException is not thrown. I guess this should be fixed, but in the meanwhile I opened this pull request to make both processor working in any situation, and consistent with each other.