### PR TITLE
Fix AttachDUT to take into account the case when the DUT is 1D Strip …

### DIFF
--- a/eutelescope/libraries/include/EUTelTripletGBLUtility.h
+++ b/eutelescope/libraries/include/EUTelTripletGBLUtility.h
@@ -262,7 +262,7 @@ namespace eutelescope {
       //! Match the upstream and downstream triplets to tracks
       void MatchTriplets(std::vector<EUTelTripletGBLUtility::triplet> const & up, std::vector<EUTelTripletGBLUtility::triplet> const & down, double z_match, double trip_matching_cut, std::vector<EUTelTripletGBLUtility::track> &track);
 
-	  bool AttachDUT(EUTelTripletGBLUtility::triplet & triplet, std::vector<EUTelTripletGBLUtility::hit> const & hits, unsigned int dutID,  double trip_res_cut);
+	  bool AttachDUT(EUTelTripletGBLUtility::triplet & triplet, std::vector<EUTelTripletGBLUtility::hit> const & hits, unsigned int dutID,  double trip_res_cut,  int dut_dimension);
 
 	  //bool AttachDUT(std::vector<EUTelTripletGBLUtility::triplet> & triplets, std::vector<EUTelTripletGBLUtility::hit> const & hits, unsigned int dutIDs, double trip_res_cut, double trip_slope_cut);
 

--- a/eutelescope/libraries/src/EUTelTripletGBLUtility.cc
+++ b/eutelescope/libraries/src/EUTelTripletGBLUtility.cc
@@ -262,7 +262,7 @@ bool EUTelTripletGBLUtility::IsTripletIsolated(EUTelTripletGBLUtility::triplet c
   return IsolatedTrip;
 }
 
-bool EUTelTripletGBLUtility::AttachDUT(EUTelTripletGBLUtility::triplet & triplet, std::vector<EUTelTripletGBLUtility::hit> const & hits, unsigned int dutID,  double dist_cut){
+bool EUTelTripletGBLUtility::AttachDUT(EUTelTripletGBLUtility::triplet & triplet, std::vector<EUTelTripletGBLUtility::hit> const & hits, unsigned int dutID,  double dist_cut, int dut_dimension){
 
 	auto zPos = geo::gGeometry().getPlaneZPosition(dutID);
 	int minHitIx = -1;
@@ -279,7 +279,13 @@ bool EUTelTripletGBLUtility::AttachDUT(EUTelTripletGBLUtility::triplet & triplet
 		if(hit.plane == dutID) {
 			auto hitX = hit.x;
 			auto hitY = hit.y;
-			auto dist = (trX-hitX)*(trX-hitX)+(trY-hitY)*(trY-hitY);
+                        auto dist = 0;
+                        if( dut_dimension ==2) {
+			   dist = (trX-hitX)*(trX-hitX)+(trY-hitY)*(trY-hitY);
+                        }
+                        else {
+                           dist = (trX-hitX)*(trX-hitX); //when the dut is Strip sensor, assume the dut is placed with the strips along the global y-direction so the measurment is along the global x-direction;
+                        }
 //			std::cout << "Hit x/y: " << hitX << "|" << hitY << " dist: " << dist << '\n'; 
 			if(dist <= cut_squared && dist < minDist ){
 				minHitIx = static_cast<int>(ix);

--- a/jobsub/examples/gbl_local/steering-templates/aligngbl-tmp.xml
+++ b/jobsub/examples/gbl_local/steering-templates/aligngbl-tmp.xml
@@ -119,6 +119,8 @@
   <parameter name="resolutionX" type="FloatVec"> @XResidualVec@ </parameter>
   <!--y-resolution of sensors (z-ordered) [mm]-->
   <parameter name="resolutionY" type="FloatVec"> @YResidualVec@ </parameter>
+  <!--Plane dimension (2 for pixel sensors and 1 for strip sensors) for all planes-->
+  <parameter name="planeDimensions" type="IntVec" > @planeDimensions@ </parameter>
   <!--Upstream-downstream triplet matching cut [mm]-->
   <parameter name="tripletsMatchingCut" type="double"> @TripletMatchingCut@ </parameter>
   <!--The three sensors used as the upstream triplet-->

--- a/processors/include/EUTelAlignGBL.h
+++ b/processors/include/EUTelAlignGBL.h
@@ -176,6 +176,8 @@ namespace eutelescope {
   std::vector<float> _x_resolution_vec;
   //ResolutionY
   std::vector<float> _y_resolution_vec;
+  //plane dimensions
+  std::vector<int> _planeDimension;
 
   std::map<int, bool> _is_sensor_upstream;
 

--- a/processors/src/EUTelAlignGBL.cc
+++ b/processors/src/EUTelAlignGBL.cc
@@ -160,6 +160,7 @@ EUTelAlignGBL::EUTelAlignGBL(): Processor("EUTelAlignGBL") {
   registerOptionalParameter("lastUpstreamSensor","The last plane (z-ordered) which still should be attached to the upstream triplet", _last_upstream_sensor, 2);
   registerOptionalParameter("resolutionX","x-resolution of sensors (z-ordered) [mm]", _x_resolution_vec ,std::vector<float>());
   registerOptionalParameter("resolutionY","y-resolution of sensors (z-ordered) [mm]", _y_resolution_vec ,std::vector<float>());
+  registerOptionalParameter("planeDimensions", "This is a number 1(strip sensor) or 2(pixel sensor) to identify the type of detector. Must be in z order and include all planes.", _planeDimension, IntVec());
   registerOptionalParameter("fixedPlanes","Fix sensor planes in the fit according to their sensor ids",_FixedPlanes_sensorIDs ,std::vector<int>());
   registerOptionalParameter("maxTrackCandidatesTotal","Maximal number of track candidates (Total)",_maxTrackCandidatesTotal, 10000000);
   registerOptionalParameter("maxTrackCandidates","Maximal number of track candidates",_maxTrackCandidates, 2000);
@@ -429,10 +430,13 @@ void EUTelAlignGBL::processEvent( LCEvent * event ) {
             auto& driplet = track.get_downstream();
 
             for(auto dutID: _dut_ids) {
+              auto planeIt = std::find(_sensorIDVec.begin(), _sensorIDVec.end(), dutID);
+              auto dimension = _planeDimension[planeIt - _sensorIDVec.begin()];
+              //std::cout<<"planeID = "<<dutID<< " dimension "<<dimension<<std::endl;
               if(_is_sensor_upstream[dutID]) {
-                gblutil.AttachDUT(triplet, _DUThitsVec, dutID, 3);
+                gblutil.AttachDUT(triplet, _DUThitsVec, dutID, 3 , dimension);
               } else {
-                gblutil.AttachDUT(driplet, _DUThitsVec, dutID, 3);
+                gblutil.AttachDUT(driplet, _DUThitsVec, dutID, 3 , dimension);
               }
             }
 /*


### PR DESCRIPTION
Modify the EUTelTripletGBLUtility::AttachDUT to take into account the possible dimension of the DUT and fix the AttachDUT in the EUTelAlignGBL processor.
After the above fix, in the config file, a vector of int ('planeDimensions') to denote the dimensions of all planes must be provided where '1' is for Strip sensor and '2' for pixel sensor.