### PR TITLE
Bug fix for missing EUTelMille processor

### DIFF
--- a/processors/src/legacy/EUTelDafAlign.cc
+++ b/processors/src/legacy/EUTelDafAlign.cc
@@ -41,8 +41,9 @@
  * If youc cpu supports it, you could try -msse4 or -msse3 aswell.
  */
 
-// built only if GEAR and MARLINUTIL are used
+// built only if GEAR is used
 #if defined(USE_GEAR)
+
 // eutelescope includes ".h"
 #include "EUTelDafAlign.h"
 #include "EUTELESCOPE.h"

--- a/processors/src/legacy/EUTelDafBase.cc
+++ b/processors/src/legacy/EUTelDafBase.cc
@@ -42,7 +42,7 @@
  */
 
 
-// built only if GEAR and MARLINUTIL are used
+// built only if GEAR is used
 #if defined(USE_GEAR)
 
 // eutelescope includes ".h"

--- a/processors/src/legacy/EUTelDafFitter.cc
+++ b/processors/src/legacy/EUTelDafFitter.cc
@@ -41,7 +41,7 @@
  * If your cpu supports it, you could try -msse4 or -msse3 as well.
  */
 
-// built only if GEAR and MARLINUTIL are used
+// built only if GEAR is used
 #if defined(USE_GEAR)
 
 // eutelescope includes ".h"

--- a/processors/src/legacy/EUTelDafMaterial.cc
+++ b/processors/src/legacy/EUTelDafMaterial.cc
@@ -40,8 +40,9 @@
  * If youc cpu supports it, you could try -msse4 or -msse3 aswell.
  */
 
-// built only if GEAR and MARLINUTIL are used
+// built only if GEAR is used
 #if defined(USE_GEAR)
+
 // eutelescope includes ".h"
 #include "EUTelDafMaterial.h"
 #include "EUTELESCOPE.h"

--- a/processors/src/legacy/EUTelMille.cc
+++ b/processors/src/legacy/EUTelMille.cc
@@ -9,8 +9,8 @@
  *   header with author names in all development based on this file.
  *
  */
-// built only if GEAR and MARLINUTIL are used
-#if defined(USE_GEAR) && defined(USE_MARLINUTIL)
+// built only if GEAR is used
+#if defined(USE_GEAR)
 
 // eutelescope includes ".h"
 #include "EUTelMille.h"


### PR DESCRIPTION
Answering issue #478, it was found, that EUTelMille processor is only build, when MARLINUTIL is available.
Due to changes in ilCInstall, MARLINUTIL is no longer installed, therefore in commit [889d348](https://github.com/eutelescope/eutelescope/commit/889d3488ce18aad142a486ef4a0e08ed95f593c8) the dependency was removed in CMakeLists, but it was overseen the requirement in EUTelMille, which seems to be anyway obsolete. Therefore, it is now removed and EUTelMille should be buildable again.
Also now misleading comments in the DAF processors about MARLINUTIL are removed with this.