### PR TITLE
FIX: add missing std:: namespace

### DIFF
--- a/eutelescope/libraries/include/EUTelCDashMeasurement.h
+++ b/eutelescope/libraries/include/EUTelCDashMeasurement.h
@@ -121,7 +121,7 @@ public:
   }
 #else
   // no output case (if testing precompiler flag is not set:)
-  friend ostream &operator<<(ostream &os, const CDashMeasurement &) {
+  friend std::ostream &operator<<(std::ostream &os, const CDashMeasurement &) {
     return os;
   }
 


### PR DESCRIPTION
Error came only now due to bug fix of EUTelMille and the deletion of flag -DO_TESTING in CMakeLists from before.